### PR TITLE
pass string from ObjectName::class instead of actual hard coded string.

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -31,7 +31,7 @@ class Item extends AbstractModel implements ItemInterface, IdentityInterface
      */
     protected function _construct()
     {
-        $this->_init('ScandiPWA\MenuOrganizer\Model\ResourceModel\Item');
+        $this->_init(\ScandiPWA\MenuOrganizer\Model\ResourceModel\Item::class);
     }
 
     /**


### PR DESCRIPTION
if anything, allows for a developer to command+click / control+click the value rather than having to manually navigate to it.