### PR TITLE
fixed error when trying to use filter fields for menu items

### DIFF
--- a/src/Model/ResourceModel/Item/Collection.php
+++ b/src/Model/ResourceModel/Item/Collection.php
@@ -37,6 +37,10 @@ class Collection extends AbstractCollection
             ['parent_title' => 'title']
         )->order('main_table.item_id ASC');
 
+        $this->addFilterToMap('is_active', 'main_table.is_active');
+        $this->addFilterToMap('item_class', 'main_table.item_class');
+        $this->addFilterToMap('position', 'main_table.position');
+
         return $this;
     }
 


### PR DESCRIPTION
fixes an error for ambiguous field definition when trying to search menu items by “Item CSS Class”, “Position” and “Status”.

Fixes scandipwa/scandipwa#2494