### PR TITLE
#3024 Show CMS option select only if chosen

### DIFF
--- a/src/view/adminhtml/web/item-actions-handler.js
+++ b/src/view/adminhtml/web/item-actions-handler.js
@@ -19,7 +19,7 @@ define([
         options: {
             customUrl: '.field-url',
             categorySelect: '.field-category_id',
-            cmsPageSelect: '.field-cms_page_identifier'
+            cmsPageSelect: '.field-cms_page_id'
         },
         activeUrlType: 0,
 


### PR DESCRIPTION
Original issue:
https://github.com/scandipwa/scandipwa/issues/3024

In this PR:
* Fixed field selector so that it hides CMS options when not needed